### PR TITLE
first imp for dns reverse lookup name parsing and resolution

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1222,6 +1222,7 @@ struct ndpi_flow_struct {
       u_int8_t num_queries, num_answers, reply_code, is_query;
       u_int16_t query_type, query_class, rsp_type;
       u_int32_t answer_ttl;
+      char answer_domain[32];
       ndpi_ip_addr_t rsp_addr; /* The first address in a DNS response packet */
     } dns;
 

--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1222,7 +1222,7 @@ struct ndpi_flow_struct {
       u_int8_t num_queries, num_answers, reply_code, is_query;
       u_int16_t query_type, query_class, rsp_type;
       u_int32_t answer_ttl;
-      char answer_domain[32];
+      char answer_domain[256];
       ndpi_ip_addr_t rsp_addr; /* The first address in a DNS response packet */
     } dns;
 

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -320,6 +320,8 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
             // reverse dns lookup responses can have an address section and a domain name section 
             // since we already have the address from the query we just need the domain name
             int section_len = packet->payload[x]; // get 1st segment len
+            // if first char is number this is an address 
+            // number can't be first char in domain name
             if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
             {
               x += section_len +1; // skip  segment len + address field 
@@ -332,6 +334,7 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
               data_len--;
             } 
 
+            // copy domain name to field
             if (data_len > 32)
               memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
             else

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -324,7 +324,7 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
             // number can't be first char in domain name
             if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
             {
-              x += section_len +1; // skip  segment len + address field 
+              x += section_len + 1; // skip  segment len + address field 
               data_len -= section_len + 1; // adjust data_len for copying
             }
             // if block to remove the next segment length from the front of the string
@@ -335,8 +335,8 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
             } 
 
             // copy domain name to field
-            if (data_len > 32)
-              memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
+            if (data_len >= 32)
+              memcpy(&flow->protos.dns.answer_domain, packet->payload + x, sizeof(flow->protos.dns.answer_domain)-1); // make sure buf is null terminated
             else
               memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);
           }

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -315,6 +315,28 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
 		  )) {
 		memcpy(&flow->protos.dns.rsp_addr, packet->payload + x, data_len);
 	      }
+        else if (rsp_type == 0x0c)
+        {
+          // reverse dns lookup responses can have an address section and a domain name section 
+          // since we already have the address from the query we just need the domain name
+          int section_len = packet->payload[x]; // get 1st segment len
+          if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
+          {
+            x += section_len +1; // skip  segment len + address field 
+            data_len -= section_len + 1; // adjust data_len for copying
+          }
+          // if block to remove the next segment length from the front of the string
+          if (data_len > 0)
+          {
+            x++;
+            data_len--;
+          }
+
+          if (data_len > 32)
+            memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
+          else
+            memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);
+        }
 	    }
 	  }
 

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -315,28 +315,28 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
 		  )) {
 		memcpy(&flow->protos.dns.rsp_addr, packet->payload + x, data_len);
 	      }
-        else if (rsp_type == 0x0c)
-        {
-          // reverse dns lookup responses can have an address section and a domain name section 
-          // since we already have the address from the query we just need the domain name
-          int section_len = packet->payload[x]; // get 1st segment len
-          if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
-          {
-            x += section_len +1; // skip  segment len + address field 
-            data_len -= section_len + 1; // adjust data_len for copying
-          }
-          // if block to remove the next segment length from the front of the string
-          if (data_len > 0)
-          {
-            x++;
-            data_len--;
-          }
+         else if (rsp_type == 0x0c)
+         {
+           // reverse dns lookup responses can have an address section and a domain name section 
+           // since we already have the address from the query we just need the domain name
+           int section_len = packet->payload[x]; // get 1st segment len
+           if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
+           {
+             x += section_len +1; // skip  segment len + address field 
+             data_len -= section_len + 1; // adjust data_len for copying
+           }
+           // if block to remove the next segment length from the front of the string
+           if (data_len > 0)
+           {
+             x++;
+             data_len--;
+           } 
 
-          if (data_len > 32)
-            memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
-          else
-            memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);
-        }
+           if (data_len > 32)
+             memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
+           else
+             memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);
+         }
 	    }
 	  }
 

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -320,14 +320,17 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
 
             // reverse dns lookup responses can have an address label as well as additional domain name labels 
             // since we already have the address from the query we just need the domain name
+            // we only process the first answer and grab its domain name
             int an_index = 0;
-            while((packet->payload[x] != '.') && (packet->payload[x] != '\0'))
+            // make sure to exit loop if x is a 00 octet or x exceeds the packet payload length or the length octet has first 2 bits set (domain name compressed)
+            while((packet->payload[x] != '\0') && (x < packet->payload_packet_len) && ((packet->payload[x] & 0xC0) != 0))
             {
               int label_len = packet->payload[x]; // get 1st label len
-            
+
               // if first char is number this is an address 
               // number can't be first char in domain name
-              if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
+              // we only want to check the first label for an ip address 
+              if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39 && an_index == 0)
               {
                 x += label_len + 1; // skip  label len + address field 
               }
@@ -341,6 +344,8 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
                   an_index++; // increment index for delimeter
                   x += label_len + 1; // skip  label len + address field 
                 }
+                else
+                  break;
               }
             }
             flow->protos.dns.answer_domain[an_index - 1] = '\0'; // remove trailing '.' char and replace with null term

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -335,7 +335,7 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
             } 
 
             // copy domain name to field
-            if (data_len >= 32)
+            if (data_len >= sizeof(flow->protos.dns.answer_domain))
               memcpy(&flow->protos.dns.answer_domain, packet->payload + x, sizeof(flow->protos.dns.answer_domain)-1); // make sure buf is null terminated
             else
               memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);

--- a/src/lib/protocols/dns.c
+++ b/src/lib/protocols/dns.c
@@ -315,28 +315,28 @@ static int search_valid_dns(struct ndpi_detection_module_struct *ndpi_struct,
 		  )) {
 		memcpy(&flow->protos.dns.rsp_addr, packet->payload + x, data_len);
 	      }
-         else if (rsp_type == 0x0c)
-         {
-           // reverse dns lookup responses can have an address section and a domain name section 
-           // since we already have the address from the query we just need the domain name
-           int section_len = packet->payload[x]; // get 1st segment len
-           if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
-           {
-             x += section_len +1; // skip  segment len + address field 
-             data_len -= section_len + 1; // adjust data_len for copying
-           }
-           // if block to remove the next segment length from the front of the string
-           if (data_len > 0)
-           {
-             x++;
-             data_len--;
-           } 
+          else if (rsp_type == 0x0c)
+          {
+            // reverse dns lookup responses can have an address section and a domain name section 
+            // since we already have the address from the query we just need the domain name
+            int section_len = packet->payload[x]; // get 1st segment len
+            if (packet->payload[x+1] >= 0x30 && packet->payload[x+1] <= 0x39)
+            {
+              x += section_len +1; // skip  segment len + address field 
+              data_len -= section_len + 1; // adjust data_len for copying
+            }
+            // if block to remove the next segment length from the front of the string
+            if (data_len > 0)
+            {
+              x++;
+              data_len--;
+            } 
 
-           if (data_len > 32)
-             memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
-           else
-             memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);
-         }
+            if (data_len > 32)
+              memcpy(&flow->protos.dns.answer_domain, packet->payload + x, 32);
+            else
+              memcpy(&flow->protos.dns.answer_domain, packet->payload + x, data_len);
+          }
 	    }
 	  }
 


### PR DESCRIPTION
- Adds answer_domain field of size 32 chars to the dns protos struct.
- Adds parsing to detect dns reverse lookup response type (12)
- Adds parsing to dissect sections of the reverse lookup rdata
- Parsing removes ip address from in front of domain name (already found in query)

