### PR TITLE
Updated length processing and bitmap for dhcp options

### DIFF
--- a/src/include/ndpi_typedefs.h
+++ b/src/include/ndpi_typedefs.h
@@ -1295,7 +1295,7 @@ struct ndpi_flow_struct {
       u_int32_t requested_ip; /* option 50 */
       u_int32_t lease_time; /* option 51 */
       u_int8_t msg_type; /* option 53 */
-      u_int8_t valid; /* signifies valid dhcp resp */
+      u_int8_t valid; /* signifies valid dhcp resp bitmap for valid ip addr options as well 50,54*/
       ndpi_ip_addr_t server_ident; /* option 54 */
       char fingerprint[48]; /* option 55 */
       u_int32_t renew_time; /* option 58 */

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -174,29 +174,23 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 	      //	    while(j < len) { printf( "%c", name[j]); j++; }; printf("\n");
 #endif
             ndpi_hostname_sni_set(flow, name, len);
-          } else if(id == 15 /* Domain Name */) {
+	        } else if(id == 15 /* Domain Name */) {
             char *name = (char*)&dhcp->options[i+2];
             int j = 0;
-
+	    
             j = ndpi_min(len, sizeof(flow->protos.dhcp.domain_name)-1);
             strncpy((char*)flow->protos.dhcp.domain_name, name, j);
             flow->protos.dhcp.domain_name[j] = '\0';
           } else if(id == 50) /* Requested IP */ {
-            if (len > sizeof(flow->protos.dhcp.requested_ip))
-              len = sizeof(flow->protos.dhcp.requested_ip);
-            memcpy(&flow->protos.dhcp.requested_ip, (char*)&dhcp->options[i+2], len); 
+              flow->protos.dhcp.valid |= 0x02 ;
+              memcpy(&flow->protos.dhcp.requested_ip, (char*)&dhcp->options[i+2], ndpi_min(sizeof(flow->protos.dhcp.requested_ip), len)); 
           } else if(id == 51) /* Lease Time */ {
-            if (len > sizeof(flow->protos.dhcp.lease_time))
-              len = sizeof(flow->protos.dhcp.lease_time);
-            memcpy(&flow->protos.dhcp.lease_time, (char*)&dhcp->options[i+2], len);  
+              memcpy(&flow->protos.dhcp.lease_time, (char*)&dhcp->options[i+2], ndpi_min(sizeof(flow->protos.dhcp.lease_time),len)); 
           } else if(id == 54) /* Server Identifier */ {
-            if (len > sizeof(flow->protos.dhcp.server_ident))
-              len = sizeof(flow->protos.dhcp.server_ident);
-            memcpy(&flow->protos.dhcp.server_ident, (char*)&dhcp->options[i+2], len);
+              flow->protos.dhcp.valid |= 0x04;
+              memcpy(&flow->protos.dhcp.server_ident, (char*)&dhcp->options[i+2], ndpi_min(sizeof(flow->protos.dhcp.server_ident), len)); 
           } else if(id == 58) /* Renewal Time */ {
-            if (len > sizeof(flow->protos.dhcp.renew_time))
-              len = sizeof(flow->protos.dhcp.renew_time);
-            memcpy(&flow->protos.dhcp.renew_time, (char*)&dhcp->options[i+2], len); 
+              memcpy(&flow->protos.dhcp.renew_time, (char*)&dhcp->options[i+2], ndpi_min(sizeof(flow->protos.dhcp.renew_time), len)); 
           }
           i += len + 2;
         }

--- a/src/lib/protocols/dhcp.c
+++ b/src/lib/protocols/dhcp.c
@@ -101,7 +101,7 @@ void ndpi_search_dhcp_udp(struct ndpi_detection_module_struct *ndpi_struct, stru
 
             if(msg_type <= 8) {
               foundValidMsgType = 1;
-              flow->protos.dhcp.valid = 1;
+              flow->protos.dhcp.valid |= 0x01;
               break;
             }
           }


### PR DESCRIPTION
Refactor length check for dhcp options to utilize ndpi_min (Seth's suggestion) also modified dhcp.valid field to function as a bitmap for identifying whether certain options have a valid value even if that value is 0